### PR TITLE
Updated Condition according to V5

### DIFF
--- a/input/fsh/Profiles clinical datapoints/BodyMeasures.fsh
+++ b/input/fsh/Profiles clinical datapoints/BodyMeasures.fsh
@@ -8,6 +8,7 @@ Description: "Height of a person diagnosed with breast cancer"
 * subject only Reference(BreastCancerPatient)
 * valueQuantity.value MS
 * valueQuantity.unit MS
+* valueQuantity.code MS
 
 Instance: BodyHeightPatient147
 InstanceOf: BodyHeight
@@ -15,7 +16,7 @@ Description: "Example of the height of a patient diagnosed with breast cancer"
 * status = ObservationStatusCS#final
 * subject = Reference(BreastCancerPatient147)
 * valueQuantity.value = 48
-* valueQuantity.unit = "inches"
+* valueQuantity.unit = "in_i"
 * valueQuantity.code = UCUM#[in_i]
 * effectiveDateTime = "2019-04-01" 
 
@@ -37,16 +38,19 @@ Description: "The weight of a person diagnosed with breastcancer"
 * insert PublicationProfileRuleset
 * subject only Reference(BreastCancerPatient)
 * valueQuantity.value MS
+* valueQuantity.unit from BodyWeightVS
 * valueQuantity.unit MS
+* valueQuantity.code MS
 
 Instance: BodyWeightPatient147
 InstanceOf: BodyWeight
 Description: "Example of the weight of a patient diagnosed with breast cancer"
 * status = ObservationStatusCS#final
 * subject = Reference(BreastCancerPatient147)
-* valueQuantity.value = 482
-* valueQuantity.unit = "lbs"
-* valueQuantity.code = UCUM#[lb_av]
+* valueQuantity.value = 70
+* valueQuantity.unit = "kg"
+* valueQuantity.code = #kg
+* valueQuantity.system = UCUM
 * effectiveDateTime = "2019-04-01"
 
 Mapping: BodyWeightToICHOM

--- a/input/fsh/Profiles clinical datapoints/Condition.fsh
+++ b/input/fsh/Profiles clinical datapoints/Condition.fsh
@@ -36,8 +36,11 @@ Title: "Secondary Breast Cancer Condition"
 Description: "Represent the properties of the secondary breast cancer diagnosis"
 * insert PublicationProfileRuleset
 * code = SCT#145501000119108 "Secondary malignant neoplasm of breast"
+* subject only Reference(BreastCancerPatient)
 * bodySite from NewCancerVS
 * bodySite MS
+* clinicalStatus MS
+* recordedDate MS
 
 Instance: SecondaryBreastCancerPatient147
 InstanceOf: SecondaryBreastCancerCondition
@@ -45,6 +48,7 @@ Description: "Example of the secondary condition breast cancer diagnosed in a pa
 * code = SCT#145501000119108 "Secondary malignant neoplasm of breast"
 * clinicalStatus = ConditionStatusCS#active "Active"
 * bodySite = SCT#255209002 "Contralateral"
+* subject = Reference(BreastCancerPatient147)
 
 Mapping: SecondaryBreastCancerConditionToICHOM
 Source:	SecondaryBreastCancerCondition

--- a/input/fsh/Profiles clinical datapoints/Condition.fsh
+++ b/input/fsh/Profiles clinical datapoints/Condition.fsh
@@ -1,3 +1,4 @@
+// Primary Breast Cancer
 Profile: PrimaryBreastCancerCondition
 Parent: Condition 
 Id: primary-breastcancer
@@ -6,14 +7,13 @@ Description: "Represent the properties of the primary breast cancer diagnosis."
 * insert PublicationProfileRuleset
 * code = SCT#372137005 "Primary malignant neoplasm of breast"
 * subject only Reference(BreastCancerPatient)
-* bodySite from LateralityVS (required)
 * bodySite MS
 * clinicalStatus MS
 * recordedDate MS
 
-Instance: ConditionPatient147
+Instance: PrimaryBreastCancerPatient147
 InstanceOf: PrimaryBreastCancerCondition
-Description: "Example of the condition breast cancer diagnosed in a patient"
+Description: "Example of the primary condition breast cancer diagnosed in a patient"
 * code = SCT#372137005 "Primary malignant neoplasm of breast"
 * clinicalStatus = ConditionStatusCS#recurrence "Recurrence"
 * bodySite = SCT#80248007 "Left breast"
@@ -26,20 +26,32 @@ Id: primaryconditionmapping
 Title: "Primary condition to ICHOM set"
 Description: "Mapping of the primary breast cancer condition to the ICHOM breast cancer PCOM set. To ensure this is the first breast cancer diagnosed in a patient, the application can search for previous conditions." 	
 * -> "First breast cancer"
-* bodySite -> "Laterality"
 * clinicalStatus -> "Recurrence" 
 
+// Secondary Breast Cancer
+Profile: SecondaryBreastCancerCondition
+Parent: Condition 
+Id: secondary-breastcancer
+Title: "Secondary Breast Cancer Condition"
+Description: "Represent the properties of the secondary breast cancer diagnosis"
+* insert PublicationProfileRuleset
+* code = SCT#145501000119108 "Secondary malignant neoplasm of breast"
+* bodySite from NewCancerVS
+* bodySite MS
 
+Instance: SecondaryBreastCancerPatient147
+InstanceOf: SecondaryBreastCancerCondition
+Description: "Example of the secondary condition breast cancer diagnosed in a patient"
+* code = SCT#145501000119108 "Secondary malignant neoplasm of breast"
+* clinicalStatus = ConditionStatusCS#active "Active"
+* bodySite = SCT#255209002 "Contralateral"
 
-// Profile: SecondaryBreastCancerCondition
-// Parent: Condition 
-// Id: secondary-breastcancer
-// Title: "Secondary Breast Cancer Condition"
-// Description: "Represent the properties of the Secondary breast cancer diagnosis"
-// * insert PublicationProfileRuleset
-// * code = SCT#145501000119108 "Secondary malignant neoplasm of breast"
-// * bodySite from LateralityVS
-// * bodySite MS
-
+Mapping: SecondaryBreastCancerConditionToICHOM
+Source:	SecondaryBreastCancerCondition
+Target: "https://connect.ichom.org/patient-centered-outcome-measures/breast-cancer"
+Id: secondaryconditionmapping
+Title: "Secondary condition to ICHOM set"
+Description: "Mapping of the secondary breast cancer condition to the ICHOM breast cancer PCOM set. To ensure this is secondary breast cancer diagnosed in a patient, the application can search for previous conditions." 	
+* -> "New cancer"
 
 

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -23,7 +23,7 @@ ValueSet: DemographicFactorsRace
 Id: DemographicFactorsRace
 Title: "Race of patient"
 Description: "Valueset of the race of a patient"
-* include codes from system RaceVS
+* include codes from valueset RaceVS
 // Remove this valueset once we have a snowmed-supporting server since this is only a shell valueset 
 
 ValueSet: RelationshipStatusVS
@@ -155,13 +155,20 @@ Description: "Patient's documented history of comorbidities"
 * include SACQPatientComorbidityCodeSystem#13 "Rheumatoid arthritis"
 * include SACQPatientComorbidityCodeSystem#14 "Other medical problems"
 
-ValueSet: LateralityVS
-Id: LateralityVS
-Title: "Laterality of breast cancer"
-Description: "Valueset of the laterality of breast cancer"
-* SCT#80248007 "Left breast structure"
-* SCT#73056007 "Right breast structure"
-* SCT#63762007 "Both breasts"
+// ValueSet: LateralityVS
+// Id: LateralityVS
+// Title: "Laterality of breast cancer"
+// Description: "Valueset of the laterality of breast cancer"
+// * SCT#80248007 "Left breast structure"
+// * SCT#73056007 "Right breast structure"
+// * SCT#63762007 "Both breasts"
+
+ValueSet: NewCancerVS
+Id: NewCancerVS
+Title: "Laterality of new cancer"
+Description: "Valueset of the laterality of new breast cancer"
+* SCT#255208005 "Ipsilateral"
+* SCT#255209002 "Contralateral"
 
 //  TREATMENT VARIABLES 
 

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -155,6 +155,21 @@ Description: "Patient's documented history of comorbidities"
 * include SACQPatientComorbidityCodeSystem#13 "Rheumatoid arthritis"
 * include SACQPatientComorbidityCodeSystem#14 "Other medical problems"
 
+ValueSet: BodyWeightVS
+Id: BodyWeightVS
+Title: "Units of patient's body weight"
+Description: "Valueset of the unit  of the patient's body weight"
+* UCUM#kg "kg"
+* UCUM#[lb_av] "[lb_av]"
+
+// ValueSet: BodyHeightVS
+// Id: BodyHeightVS
+// Title: "Units of patient's body height"
+// Description: "Valueset of the unit  of the patient's body height"
+// * UCUM#cm "cm" 
+// * UCUM#[in_i] "in_i"
+// We probalby need this VS for the questionnaires, so I'll leave it here for now
+
 // ValueSet: LateralityVS
 // Id: LateralityVS
 // Title: "Laterality of breast cancer"

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -162,22 +162,6 @@ Description: "Valueset of the unit  of the patient's body weight"
 * UCUM#kg "kg"
 * UCUM#[lb_av] "[lb_av]"
 
-// ValueSet: BodyHeightVS
-// Id: BodyHeightVS
-// Title: "Units of patient's body height"
-// Description: "Valueset of the unit  of the patient's body height"
-// * UCUM#cm "cm" 
-// * UCUM#[in_i] "in_i"
-// We probalby need this VS for the questionnaires, so I'll leave it here for now
-
-// ValueSet: LateralityVS
-// Id: LateralityVS
-// Title: "Laterality of breast cancer"
-// Description: "Valueset of the laterality of breast cancer"
-// * SCT#80248007 "Left breast structure"
-// * SCT#73056007 "Right breast structure"
-// * SCT#63762007 "Both breasts"
-
 ValueSet: NewCancerVS
 Id: NewCancerVS
 Title: "Laterality of new cancer"
@@ -185,9 +169,10 @@ Description: "Valueset of the laterality of new breast cancer"
 * SCT#255208005 "Ipsilateral"
 * SCT#255209002 "Contralateral"
 
+
 //  TREATMENT VARIABLES 
 
-// TreatmentType \\
+// TreatmentType 
 CodeSystem: TreatmentTypesCodeSystem
 Id: TreatmentTypesCodeSystem
 Title: "Treatment variables"
@@ -220,7 +205,7 @@ Description: "Valueset of the kind of treatment a patient underwent"
 * include TreatmentTypesCodeSystem#8 "Best supportive care"
 * include NullFlavor#ASKU "asked but unknown"
 
-// Breast Surgery Type \\
+// Breast Surgery Type 
 CodeSystem: BreastSurgeryTypesCodeSystem
 Id: BreastSurgeryTypesCodeSystem
 Title: "Breast surgery Types"


### PR DESCRIPTION
I updated the baseline clinical factors according to V5, which only involved adding a secondary cancer condition profile.
Also I limited the weight units to limit the unit options to only kg and pounds, as previously discussed in the CIC meeting. 

The only question I still have is that in the same CIC call, Kurt mentioned that our code for primary cancer condition is too strict and that we probably have to slice it? I don't really know how to do that and what type of codes to use then. Do you have any ideas? 