### PR TITLE
Update AJCC codes to Snomedcodes

### DIFF
--- a/input/fsh/Profiles clinical datapoints/RulesetsProfiles.fsh
+++ b/input/fsh/Profiles clinical datapoints/RulesetsProfiles.fsh
@@ -6,10 +6,6 @@ RuleSet: SNOMEDCopyrightForVS
 RuleSet: LOINCCopyrightForVS
 * ^copyright = "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc"
 
-// Copyrights AJCC
-RuleSet: AJCCCopyrightForVS
-* ^copyright = "Used with permission of the American College of Surgeons, Chicago, Illinois. The original source for this information is the AJCC Cancer Staging System (2020)."
-
 // Copyrights HL7
 RuleSet: HL7CopyrightForVS
 * ^copyright = "Copyright HL7. Licensed under creative commons public domain"

--- a/input/fsh/Profiles clinical datapoints/TumorStaging.fsh
+++ b/input/fsh/Profiles clinical datapoints/TumorStaging.fsh
@@ -67,7 +67,7 @@ Description: "Extended example: example showing clinical TNM staging (T)"
 * status = #final "final"
 * code = SCT#385356007 "Tumor stage finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#Tis(Paget)
+* valueCodeableConcept = SCT#1228888009 "American Joint Committee on Cancer cTis(Paget)"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Instance: PathologicalTumorStagePatient147
@@ -76,7 +76,7 @@ Description: "Extended example: example showing patholgical TNM staging (T)"
 * status = #final "final"
 * code = SCT#385356007 "Tumor stage finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#Tis(Paget)
+* valueCodeableConcept = SCT#1228956002 "American Joint Committee on Cancer pTis(Paget)"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Mapping: TNMPrimaryTumorStageToICHOM
@@ -108,7 +108,7 @@ Description: "Extended example: example showing clinical TNM staging (N)"
 * status = #final "final"
 * code = SCT#385382003 "Node stage finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#N1
+* valueCodeableConcept = SCT#1229973008 "American Joint Committee on Cancer cN1"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Instance: PathologicalNodalStagePatient147
@@ -117,7 +117,7 @@ Description: "Extended example: example showing patholgical TNM staging (N)"
 * status = #final "final"
 * code = SCT#385382003 "Node stage finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#N0
+* valueCodeableConcept = SCT#1229947003 "American Joint Committee on Cancer pN0"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Mapping: TNMRegionalNodalStageToICHOM
@@ -149,7 +149,7 @@ Description: "Extended example: example showing clinical TNM staging (M)"
 * status = #final "final"
 * code = SCT#385380006 "Metastasis category finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#M1
+* valueCodeableConcept = SCT#1229903009 "American Joint Committee on Cancer cM1"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Instance: PathologicalMetastasesPatient147
@@ -158,7 +158,7 @@ Description: "Extended example: example showing patholgical TNM staging (M)"
 * status = #final "final"
 * code = SCT#385380006 "Metastasis category finding"
 * subject = Reference(BreastCancerPatient147)
-* valueCodeableConcept = AJCC#M1
+* valueCodeableConcept = SCT#1229916009 "American Joint Committee on Cancer pM1"
 * focus = Reference(PrimaryBreastCancerPatient147)
 
 Mapping: TNMDistantMetastasesToICHOM

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -99,6 +99,8 @@ Description: "Valueset of the TNM stage for the T category, according to TNM sta
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMPrimaryTumorVS
 
+* SCT#1222604002 "American Joint Committee on Cancer cTX"
+* SCT#1228882005 "American Joint Committee on Cancer cT0"
 * SCT#1228885007 "American Joint Committee on Cancer cTis(DCIS)"
 * SCT#1228888009 "American Joint Committee on Cancer cTis(Paget)"
 * SCT#1228889001 "American Joint Committee on Cancer cT1"
@@ -106,6 +108,8 @@ Description: "Valueset of the TNM stage for the T category, according to TNM sta
 * SCT#1228938002 "American Joint Committee on Cancer cT3"
 * SCT#1228944003 "American Joint Committee on Cancer cT4"
 
+* SCT#1228950008 "American Joint Committee on Cancer pTX"
+* SCT#1228951007 "American Joint Committee on Cancer pT0"
 * SCT#1228954004 "American Joint Committee on Cancer pTis(DCIS)"
 * SCT#1228956002 "American Joint Committee on Cancer pTis(Paget)"
 * SCT#1228957006 "American Joint Committee on Cancer pT1"

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -107,7 +107,6 @@ Description: "Valueset of the TNM stage for the T category, according to TNM sta
 * SCT#1228929004 "American Joint Committee on Cancer cT2"
 * SCT#1228938002 "American Joint Committee on Cancer cT3"
 * SCT#1228944003 "American Joint Committee on Cancer cT4"
-
 * SCT#1228950008 "American Joint Committee on Cancer pTX"
 * SCT#1228951007 "American Joint Committee on Cancer pT0"
 * SCT#1228954004 "American Joint Committee on Cancer pTis(DCIS)"
@@ -122,7 +121,7 @@ ValueSet: TNMRegionalNodesVS
 Id: TNMRegionalNodesVS
 Title: "TNM Regional Nodes ValueSet"
 Description: "Valueset of the TNM stage for the N category, according to TNM staging rules"
-* insert AJCCCopyrightForVS
+* insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMRegionalNodesVS
 * SCT#1229966003 "American Joint Committee on Cancer cNX"
@@ -130,20 +129,18 @@ Description: "Valueset of the TNM stage for the N category, according to TNM sta
 * SCT#1229973008 "American Joint Committee on Cancer cN1"
 * SCT#1229978004 "American Joint Committee on Cancer cN2"
 * SCT#1229984001 "American Joint Committee on Cancer cN3"
-
 * SCT#1229945006 "American Joint Committee on Cancer pNX"
 * SCT#1229947003 "American Joint Committee on Cancer pN0"
 * SCT#1229951001 "American Joint Committee on Cancer pN1"
 * SCT#1229957002 "American Joint Committee on Cancer pN2"
 * SCT#1229962001 "American Joint Committee on Cancer pN3"
-
 * NullFlavor#UNK "unknown"
 
 ValueSet: TNMDistantMetastasesVS
 Id: TNMDistantMetastasesVS
 Title: "TNM Distant Metastases ValueSet"
 Description: "Valueset of the TNM stage for the M category, according to TNM staging rules"
-* insert AJCCCopyrightForVS
+* insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMDistantMetastasesVS
 

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -149,6 +149,7 @@ Description: "Valueset of the TNM stage for the M category, according to TNM sta
 
 * SCT#1229901006 "American Joint Committee on Cancer cM0"
 * SCT#1229903009 "American Joint Committee on Cancer cM1"
+// also need a code here for pM0
 * SCT#1229916009 "American Joint Committee on Cancer pM1"
 * NullFlavor#UNK "unknown"
 

--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -95,17 +95,23 @@ ValueSet: TNMPrimaryTumorVS
 Id: TNMPrimaryTumorVS
 Title: "TNM Primary Tumor ValueSet"
 Description: "Valueset of the TNM stage for the T category, according to TNM staging rules"
-* insert AJCCCopyrightForVS
+* insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMPrimaryTumorVS
-* AJCC#Tx "Tx"
-* AJCC#T0 "T0"
-* AJCC#Tis(DCIS) "Tis (DCIS)"
-* AJCC#Tis(Paget) "Tis (Paget)"
-* AJCC#T1 "T1"
-* AJCC#T2 "T2"
-* AJCC#T3 "T3"
-* AJCC#T4 "T4"
+
+* SCT#1228885007 "American Joint Committee on Cancer cTis(DCIS)"
+* SCT#1228888009 "American Joint Committee on Cancer cTis(Paget)"
+* SCT#1228889001 "American Joint Committee on Cancer cT1"
+* SCT#1228929004 "American Joint Committee on Cancer cT2"
+* SCT#1228938002 "American Joint Committee on Cancer cT3"
+* SCT#1228944003 "American Joint Committee on Cancer cT4"
+
+* SCT#1228954004 "American Joint Committee on Cancer pTis(DCIS)"
+* SCT#1228956002 "American Joint Committee on Cancer pTis(Paget)"
+* SCT#1228957006 "American Joint Committee on Cancer pT1"
+* SCT#1229852009 "American Joint Committee on Cancer pT2"
+* SCT#1229859000 "American Joint Committee on Cancer pT3"
+* SCT#1229864001 "American Joint Committee on Cancer pT4"
 * NullFlavor#UNK "unknown"
 
 ValueSet: TNMRegionalNodesVS
@@ -115,12 +121,18 @@ Description: "Valueset of the TNM stage for the N category, according to TNM sta
 * insert AJCCCopyrightForVS
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMRegionalNodesVS
+* SCT#1229966003 "American Joint Committee on Cancer cNX"
+* SCT#1229967007 "American Joint Committee on Cancer cN0"
+* SCT#1229973008 "American Joint Committee on Cancer cN1"
+* SCT#1229978004 "American Joint Committee on Cancer cN2"
+* SCT#1229984001 "American Joint Committee on Cancer cN3"
 
-* AJCC#Nx "Nx"
-* AJCC#N0 "N0"
-* AJCC#N1 "N1"
-* AJCC#N2 "N2"
-* AJCC#N3 "N3"
+* SCT#1229945006 "American Joint Committee on Cancer pNX"
+* SCT#1229947003 "American Joint Committee on Cancer pN0"
+* SCT#1229951001 "American Joint Committee on Cancer pN1"
+* SCT#1229957002 "American Joint Committee on Cancer pN2"
+* SCT#1229962001 "American Joint Committee on Cancer pN3"
+
 * NullFlavor#UNK "unknown"
 
 ValueSet: TNMDistantMetastasesVS
@@ -131,8 +143,9 @@ Description: "Valueset of the TNM stage for the M category, according to TNM sta
 * insert ValuesetRuleset
 * ^url = https://connect.ichom.org/fhir/ValueSet/TNMDistantMetastasesVS
 
-* AJCC#M0 "M0"
-* AJCC#M1 "M1"
+* SCT#1229901006 "American Joint Committee on Cancer cM0"
+* SCT#1229903009 "American Joint Committee on Cancer cM1"
+* SCT#1229916009 "American Joint Committee on Cancer pM1"
 * NullFlavor#UNK "unknown"
 
 ValueSet: EstrogenStatusVS


### PR DESCRIPTION
I've update the terminology of the TNM scores to snomed codes. 

The only code that I cannot find is code for pM0 code. All the other codes are now in the valuesets for TNM. 

Currently, the per category both clinical and pathological codes are in the same valueSet. This might be confusing, but it is according to the IG of mCode. 