### PR TITLE
FHIR-39975 Update gender to sexforclinicaluse

### DIFF
--- a/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
+++ b/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
@@ -9,7 +9,7 @@ Description: "A patient who has been diagnosed with or is receiving medical trea
 * address.country from CountryVS (required)
 * address.country 0..1 MS
 * maritalStatus from RelationshipStatusVS (required)
-* extension contains SexForClinicalUse named sexForClinicalUse 0..1 MS
+* extension contains http://hl7.org/fhir/StructureDefinition/patient-sexForClinicalUse named sexForClinicalUse 0..1 MS
 * extension contains EducationLevel named educationLevel 0..1 MS
 * extension contains Ethnicity named ethnicity 0..1 MS
 * extension contains Race named race 0..1 MS

--- a/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
+++ b/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
@@ -1,58 +1,61 @@
 Profile: BreastCancerPatient
-Parent: Patient 
+Parent: Patient
 Id: patient
 Title: "Breast cancer patient"
 Description: "A patient who has been diagnosed with or is receiving medical treatment for breast cancer. This profile includes the ICHOM patient characteristics and demographic factors."
 * insert PublicationProfileRuleset
-* identifier.value and name.family and birthDate and maritalStatus and deceased[x] MS 
-* deceased[x] only dateTime 
+* identifier.value and name.family and birthDate and maritalStatus and deceased[x] MS
+* deceased[x] only dateTime
 * address.country from CountryVS (required)
 * address.country 0..1 MS
 * maritalStatus from RelationshipStatusVS (required)
-* extension contains http://hl7.org/fhir/StructureDefinition/patient-sexForClinicalUse named sexForClinicalUse 0..1 MS
+* extension contains patient-sexParameterForClinicalUse named sexForClinicalUse 0..1 MS
 * extension contains EducationLevel named educationLevel 0..1 MS
 * extension contains Ethnicity named ethnicity 0..1 MS
 * extension contains Race named race 0..1 MS
 
 Instance: BreastCancerPatient147
-InstanceOf: BreastCancerPatient 
+InstanceOf: BreastCancerPatient
 Title: "Example of Breast Cancer Patient Letsche"
 Description: "The characteristics and demographic factors of an example patient."
 * identifier.value = "147"
 * name.family = "Letsche"
 * birthDate = "1920"
 * address.country = CountryCS#USA
-* extension[sexForClinicalUse].valueCodeableConcept = SexForClinicalUseCS#male
-* extension[educationLevel].valueCodeableConcept  = SCT#224297003
+* extension[sexForClinicalUse]
+  * extension[value].valueCodeableConcept = SexForClinicalUseCS#male-typical
+* extension[educationLevel].valueCodeableConcept = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2135-2
 * extension[race].valueCodeableConcept  = RaceCS#2076-8
 * maritalStatus = NullFlavor#UNK
 
 Instance: BreastCancerPatient121
-InstanceOf: BreastCancerPatient 
+InstanceOf: BreastCancerPatient
 Title: "Example of Breast Cancer Patient Cornetet"
 Description: "The characteristics and demographic factors of an example patient."
 * identifier.value = "121"
 * name.family = "Cornetet"
 * birthDate = "1933"
 * address.country = CountryCS#GB
-* extension[sexForClinicalUse].valueCodeableConcept = SexForClinicalUseCS#male
-* extension[educationLevel].valueCodeableConcept  = SCT#224297003
+* extension[sexForClinicalUse]
+  * extension[value].valueCodeableConcept = SexForClinicalUseCS#male-typical
+* extension[educationLevel].valueCodeableConcept = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2186-5
 * extension[race].valueCodeableConcept  = RaceCS#2054-5
 * maritalStatus = RelationshipStatusCS#D "Divorced"
 * deceasedDateTime = "1990-05-26"
 
 Instance: BreastCancerPatient134
-InstanceOf: BreastCancerPatient 
+InstanceOf: BreastCancerPatient
 Title: "Example of Breast Cancer Patient Mortera"
 Description: "The characteristics and demographic factors of an example patient."
 * identifier.value = "134"
 * name.family = "Mortera"
 * birthDate = "1978"
 * address.country = CountryCS#GB
-* extension[sexForClinicalUse].valueCodeableConcept =  SexForClinicalUseCS#unknown
-* extension[educationLevel].valueCodeableConcept  = SCT#224297003
+* extension[sexForClinicalUse]
+  * extension[value].valueCodeableConcept = DataAbsentCS#unknown
+* extension[educationLevel].valueCodeableConcept = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2135-2
 * extension[race].valueCodeableConcept  = RaceCS#2028-9
 * maritalStatus = RelationshipStatusCS#D "Divorced"
@@ -63,7 +66,7 @@ Source:	BreastCancerPatient
 Target: "https://connect.ichom.org/patient-centered-outcome-measures/breast-cancer"
 Id: patientmapping
 Title: "Breast cancer patient to ICHOM set"
-Description: "Mapping of the breast cancer patient profile to the ICHOM breast cancer PCOM set." 	
+Description: "Mapping of the breast cancer patient profile to the ICHOM breast cancer PCOM set."
 * identifier.value -> "Patient ID"
 * name.family -> "Last name"
 * birthDate -> "Year of birth"

--- a/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
+++ b/input/fsh/Profiles clinical datapoints/BreastCancerPatient.fsh
@@ -4,11 +4,12 @@ Id: patient
 Title: "Breast cancer patient"
 Description: "A patient who has been diagnosed with or is receiving medical treatment for breast cancer. This profile includes the ICHOM patient characteristics and demographic factors."
 * insert PublicationProfileRuleset
-* identifier.value and name.family and birthDate and gender and maritalStatus and deceased[x] MS 
+* identifier.value and name.family and birthDate and maritalStatus and deceased[x] MS 
 * deceased[x] only dateTime 
 * address.country from CountryVS (required)
 * address.country 0..1 MS
 * maritalStatus from RelationshipStatusVS (required)
+* extension contains SexForClinicalUse named sexForClinicalUse 0..1 MS
 * extension contains EducationLevel named educationLevel 0..1 MS
 * extension contains Ethnicity named ethnicity 0..1 MS
 * extension contains Race named race 0..1 MS
@@ -21,7 +22,7 @@ Description: "The characteristics and demographic factors of an example patient.
 * name.family = "Letsche"
 * birthDate = "1920"
 * address.country = CountryCS#USA
-* gender = GenderCS#male
+* extension[sexForClinicalUse].valueCodeableConcept = SexForClinicalUseCS#male
 * extension[educationLevel].valueCodeableConcept  = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2135-2
 * extension[race].valueCodeableConcept  = RaceCS#2076-8
@@ -35,7 +36,7 @@ Description: "The characteristics and demographic factors of an example patient.
 * name.family = "Cornetet"
 * birthDate = "1933"
 * address.country = CountryCS#GB
-* gender = GenderCS#male
+* extension[sexForClinicalUse].valueCodeableConcept = SexForClinicalUseCS#male
 * extension[educationLevel].valueCodeableConcept  = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2186-5
 * extension[race].valueCodeableConcept  = RaceCS#2054-5
@@ -50,7 +51,7 @@ Description: "The characteristics and demographic factors of an example patient.
 * name.family = "Mortera"
 * birthDate = "1978"
 * address.country = CountryCS#GB
-* gender = GenderCS#unknown
+* extension[sexForClinicalUse].valueCodeableConcept =  SexForClinicalUseCS#unknown
 * extension[educationLevel].valueCodeableConcept  = SCT#224297003
 * extension[ethnicity].valueCodeableConcept = EthnicityCS#2135-2
 * extension[race].valueCodeableConcept  = RaceCS#2028-9
@@ -66,11 +67,11 @@ Description: "Mapping of the breast cancer patient profile to the ICHOM breast c
 * identifier.value -> "Patient ID"
 * name.family -> "Last name"
 * birthDate -> "Year of birth"
-* gender -> "Sex"
 * deceased[x] -> "Date of death"
 * deceased[x] -> "Vital status"
 * address.country -> "Country"
 * maritalStatus -> "Relationship status"
+* extension[sexForClinicalUse] -> "Sex"
 * extension[educationLevel] -> "Level of education"
 * extension[ethnicity] -> "Ethnicity"
 * extension[race] -> "Race"

--- a/input/fsh/Profiles clinical datapoints/ListofAliases.fsh
+++ b/input/fsh/Profiles clinical datapoints/ListofAliases.fsh
@@ -26,6 +26,7 @@ Alias: EthnicityCS = http://terminology.hl7.org/CodeSystem/v3-Ethnicity
 Alias: CountryCS = urn:iso:std:iso:3166
 Alias: YesNoUnkCS = http://terminology.hl7.org/CodeSystem/v2-0532
 Alias: AdministrativeGenderCS = http://hl7.org/fhir/administrative-gender
+Alias: SexForClinicalUseCS = http://terminology.hl7.org/CodeSystem/sex-for-clinical-use
 
 // Valuesets
 Alias: EthnicityVS = http://terminology.hl7.org/ValueSet/v3-Ethnicity
@@ -46,3 +47,4 @@ Alias: ObservationExtractEx = http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc
 Alias: ObservationLinkPeriodEx = http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod
 Alias: CalculatedExpressionEx = http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression
 Alias: HiddenEx = http://hl7.org/fhir/StructureDefinition/questionnaire-hidden
+Alias: SexForClinicalUse = http://hl7.org/fhir/StructureDefinition/patient-sexForClinicalUse

--- a/input/fsh/Profiles clinical datapoints/ListofAliases.fsh
+++ b/input/fsh/Profiles clinical datapoints/ListofAliases.fsh
@@ -1,5 +1,5 @@
 // Profiles HL7 FHIR
-Alias: StandardBodyWeight = http://hl7.org/fhir/StructureDefinition/bodyweight 
+Alias: StandardBodyWeight = http://hl7.org/fhir/StructureDefinition/bodyweight
 Alias: StandardBodyHeight = http://hl7.org/fhir/StructureDefinition/bodyheight
 
 // CodeSystems:
@@ -20,18 +20,19 @@ Alias: MedicationRequestStatusCS = http://hl7.org/fhir/CodeSystem/medicationrequ
 Alias: MedicationRequestIntentCS = http://hl7.org/fhir/CodeSystem/medicationrequest-intent
 Alias: MedicationAdministrationStatusCS = http://terminology.hl7.org/CodeSystem/medication-admin-status
 
-Alias: RaceCS = http://terminology.hl7.org/CodeSystem/v3-Race 
+Alias: RaceCS = http://terminology.hl7.org/CodeSystem/v3-Race
 Alias: GenderCS = http://hl7.org/fhir/administrative-gender
 Alias: EthnicityCS = http://terminology.hl7.org/CodeSystem/v3-Ethnicity
 Alias: CountryCS = urn:iso:std:iso:3166
 Alias: YesNoUnkCS = http://terminology.hl7.org/CodeSystem/v2-0532
 Alias: AdministrativeGenderCS = http://hl7.org/fhir/administrative-gender
-Alias: SexForClinicalUseCS = http://terminology.hl7.org/CodeSystem/sex-for-clinical-use
+Alias: SexForClinicalUseCS = http://terminology.hl7.org/CodeSystem/sex-parameter-for-clinical-use
+Alias: DataAbsentCS = https://terminology.hl7.org/CodeSystem-data-absent-reason
 
 // Valuesets
 Alias: EthnicityVS = http://terminology.hl7.org/ValueSet/v3-Ethnicity
 Alias: CountryVS = 	http://hl7.org/fhir/ValueSet/iso3166-1-3
-Alias: RaceVS = http://terminology.hl7.org/ValueSet/v3-Race 
+Alias: RaceVS = http://terminology.hl7.org/ValueSet/v3-Race
 Alias: AdministrativeGenderVS = http://hl7.org/fhir/ValueSet/administrative-gender
 
 // Extensions

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -18,6 +18,7 @@ publisher:
 
 dependencies:
   hl7.fhir.uv.sdc: 3.0.0
+  hl7.fhir.uv.extensions: current
 
 pages:
   index.md:


### PR DESCRIPTION
I am currently running into an issue with adding the extension for SexForClinicalUse. When I use this extension in the Patient Profile sushi gives this error message: Cannot create sexForClinicalUse extension; unable to locate extension definition for: http://hl7.org/fhir/StructureDefinition/patient-sexForClinicalUse.

As far as I know it is not a syntax mistake, so I wonder if this extension can be used in this stage since this extension is part of the  v5.0.0-ballot FHIR Specification. So it is a pre-release publication. Could that be the reason? @vadi2 