### PR TITLE
fixed SUSHI error

### DIFF
--- a/input/fsh/Terminology.fsh
+++ b/input/fsh/Terminology.fsh
@@ -4,8 +4,6 @@ Id: RelationshipStatusVS
 Title: "Relationship status of patient ValueSet"
 Description: "Valueset of the relationship status of a patient"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/RelationshipStatusVS
-
 * RelationshipStatusCS#U "unmarried"
 * RelationshipStatusCS#M "Married"
 * RelationshipStatusCS#D "Divorced"
@@ -18,8 +16,6 @@ Title: "Education level of patient ValueSet"
 Description: "Valueset of the education level of a patient"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/EducationLevelVS
-
 * SCT#224294005 "No formal education (finding)"
 * SCT#224295006 "Only received primary school education (finding)"
 * SCT#224297003 "Educated to secondary school level (finding)"
@@ -31,8 +27,6 @@ Title: "Menopausal status of patient ValueSet"
 Description: "Valueset of the menopausal status of a patient"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/MenopausalStatusVS
-
 * SCT#309606002 "Before menopause"
 * SCT#307429007 "After menopause"
 * NullFlavor#ASKU "Asked but unknown"
@@ -44,8 +38,6 @@ Title: "Histological type of the tumor ValueSet"
 Description: "Valueset of the histological types of tumors"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/HistologicalTypeVS
-
 * SCT#399935008 "Ductal carcinoma in situ - category"
 * SCT#373395001 "Invasive ductal carcinoma with an extensive intraductal component"
 * SCT#722524005 "Primary invasive pleomorphic lobular carcinoma of breast"
@@ -58,8 +50,6 @@ Title: "Germline Mutation ValueSet"
 Description: "Valueset of the genetic mutation predisposing breast cancer"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/GermlineMutationVS
-
 * SCT#445180002 "Breast cancer genetic marker of susceptibility negative (finding)"
 * SCT#412734009 "BRCA1 gene mutation positive (finding)"
 * SCT#412738007 "BRCA2 gene mutation positive (finding)"
@@ -72,8 +62,6 @@ Title: "Grading of tumor ValueSet"
 Description: "Valueset of the grade of the tumor"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/GradingVS
-
 * SCT#399415002 "Low grade histologic differentiation (finding)"
 * SCT#405986005 "Intermediate grade histologic differentiation (finding)"
 * SCT#399611001 "High grade histologic differentiation (finding)"
@@ -86,8 +74,6 @@ Title: "Staging Type for Stage Group ValueSet"
 Description: "Valueset indicating the type of staging, clinical or pathological, of breast cancer."
 * insert LOINCCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TNMStageGroupVS
-
 * LNC#21908-9 "Stage group.clinical Cancer"
 * LNC#21902-2 "Stage group.pathology Cancer"
 
@@ -97,8 +83,6 @@ Title: "TNM Primary Tumor ValueSet"
 Description: "Valueset of the TNM stage for the T category, according to TNM staging rules"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TNMPrimaryTumorVS
-
 * SCT#1222604002 "American Joint Committee on Cancer cTX"
 * SCT#1228882005 "American Joint Committee on Cancer cT0"
 * SCT#1228885007 "American Joint Committee on Cancer cTis(DCIS)"
@@ -123,7 +107,7 @@ Title: "TNM Regional Nodes ValueSet"
 Description: "Valueset of the TNM stage for the N category, according to TNM staging rules"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TNMRegionalNodesVS
+
 * SCT#1229966003 "American Joint Committee on Cancer cNX"
 * SCT#1229967007 "American Joint Committee on Cancer cN0"
 * SCT#1229973008 "American Joint Committee on Cancer cN1"
@@ -142,8 +126,6 @@ Title: "TNM Distant Metastases ValueSet"
 Description: "Valueset of the TNM stage for the M category, according to TNM staging rules"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TNMDistantMetastasesVS
-
 * SCT#1229901006 "American Joint Committee on Cancer cM0"
 * SCT#1229903009 "American Joint Committee on Cancer cM1"
 * SCT#1229916009 "American Joint Committee on Cancer pM1"
@@ -155,8 +137,6 @@ Title: "Estrogen receptor status ValueSet"
 Description: "Valueset of the Estrogen receptor status"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/EstrogenStatusVS
-
 * SCT#373572006 "Clinical finding absent"
 * SCT#416053008 "Estrogen receptor positive tumor"
 * SCT#416237000 "Procedure not done"
@@ -168,8 +148,6 @@ Title: "Progesterone receptor status ValueSet"
 Description: "Valueset of the Progesterone receptor status"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ProgesteroneStatusVS
-
 * SCT#441118006 "Progesterone receptor negative neoplasm"
 * SCT#416561008 "Progesterone receptor positive tumor"
 * SCT#416237000 "Procedure not done"
@@ -181,8 +159,6 @@ Title: "HER2 receptor status ValueSet"
 Description: "Valueset of the HER2 receptor status"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/HER2ReceptorStatusVS
-
 * SCT#431396003 "Human epidermal growth factor 2 negative carcinoma of breast"
 * SCT#427685000 "Human epidermal growth factor 2 positive carcinoma of breast"
 * SCT#280414007 "Equivocal result"
@@ -192,7 +168,7 @@ CodeSystem: MolecularProfilingCodeSystem
 Id: MolecularProfilingCodeSystem
 Title: "Molecular Profiling CodeSystem"
 Description: "Codes used to describe the different types of molecular profiling scoring"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/MolecularProfilingCodeSystem 
+
 * insert CodeSystemRuleset
 
 * #mammaprint "Mammaprint Score" 
@@ -204,8 +180,6 @@ Id: MolecularProfilingStatusVS
 Title: "Molecular profiling"
 Description: "Valueset indicating if a molecular profiling tool was used"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/MolecularProfilingStatusVS
-
 * include MolecularProfilingCodeSystem#mammaprint "Mammaprint Score" 
 * include MolecularProfilingCodeSystem#oncotype "Oncotype Score" 
 * include MolecularProfilingCodeSystem#endopredict "Endopredict Score" 
@@ -217,8 +191,6 @@ Title: "SACQ Patient's comorbidity history ValueSet"
 Description: "Patient's documented history of comorbidities"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset 
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/SACQPatientComorbidityHistory
- 
 * include SCT#373572006 "I have no other diseases"
 * include SCT#56265001 "Heart disease (For example, angina, heart attack, or heart failure)"
 * include SCT#38341003 "High blood pressure"
@@ -241,8 +213,6 @@ Title: "Units of patient's body weight ValueSet"
 Description: "Valueset of the unit  of the patient's body weight"
 * insert UCUMCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/BodyWeightVS
-
 * UCUM#kg "kg"
 * UCUM#[lb_av] "[lb_av]"
 
@@ -252,8 +222,6 @@ Title: "Laterality of breast cancer ValueSet"
 Description: "Valueset of the laterality of breast cancer"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/LateralityVS
-
 * SCT#80248007 "Left breast structure"
 * SCT#73056007 "Right breast structure"
 * SCT#63762007 "Both breasts"
@@ -264,8 +232,6 @@ Title: "Laterality of new cancer ValueSet"
 Description: "Valueset of the laterality of new breast cancer"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/LateralityNewCancerVS
-
 * SCT#255208005 "Ipsilateral"
 * SCT#255209002 "Contralateral"
 
@@ -275,7 +241,7 @@ CodeSystem: TreatmentTypesCodeSystem
 Id: TreatmentTypesCodeSystem
 Title: "Treatment variables CodeSytem"
 Description: "Codes defining types of treatment a breast cancer patient could receive"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/TreatmentTypesCodeSystem 
+
 * insert CodeSystemRuleset
 
 * #adjuvant-chemotherapy "Adjuvant chemotherapy"
@@ -289,8 +255,6 @@ Title: "Type of treatments ValueSet"
 Description: "Valueset of the kind of treatment a patient with breastcancer underwent"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TreatmentTypeVS
-
 * include TreatmentTypesCodeSystem#no-treatment "No treatment"
 * include SCT#387713003 "Surgical procedure"
 * include SCT#699455008 "Operative procedure on axilla"
@@ -310,8 +274,6 @@ Title: "Recommended treatment types ValueSet"
 Description: "Valueset of the kind of treatment that the multidisciplinary team recommended"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/RecommendedTreatmentTypeVS
-
 * include SCT#387713003 "Surgical procedure"
 * include SCT#108290001 "Radiation oncology AND/OR radiotherapy"
 * include TreatmentTypesCodeSystem#adjuvant-chemotherapy "Adjuvant chemotherapy"
@@ -326,7 +288,7 @@ CodeSystem: BreastSurgeryTypesCodeSystem
 Id: BreastSurgeryTypesCodeSystem
 Title: "Breast surgery types CodeSystem"
 Description: "Codes indicating the types of breast surgery a patient underwent"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/BreastSurgeryTypesCodeSystem 
+
 * insert CodeSystemRuleset
 
 * #bcs "Breast conserving surgery (BCS)"
@@ -339,8 +301,6 @@ Id: BreastSurgeryTypeVS
 Title: "Types of breast surgery ValueSet"
 Description: "Valueset of the types of breast surgery a patient underwent"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/BreastSurgeryTypeVS
-
 * include BreastSurgeryTypesCodeSystem#bcs "Breast conserving surgery (BCS)"
 * include BreastSurgeryTypesCodeSystem#bcs-with-mammoplasty "BCS with mammoplasty"
 * include BreastSurgeryTypesCodeSystem#mastectomy-without-immediate-reconstruction "Mastectomy without immediate reconstruction"
@@ -354,8 +314,6 @@ Title: "Axilla surgery ValueSet"
 Description: "Valueset of surgery types of the axilla"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/AxillaSurgeryVS
-
 * SCT#396487001 "Sentinel lymph node biopsy"
 * SCT#234262008 "Excision of axillary lymph node"
 * SCT#79544006 "Complete axillary lymphadenectomy"
@@ -367,8 +325,6 @@ Title: "Targeted axilla surgery ValueSet"
 Description: "Valueset of targeted surgery types of the axilla"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TargetedAxillaSurgeryVS
-
 * SCT#396487001 "Sentinel lymph node biopsy"
 * SCT#234262008 "Excision of axillary lymph node"
 * NullFlavor#UNK "unknown"
@@ -378,7 +334,7 @@ CodeSystem: ReconstructionTypeCodeSystem
 Id: ReconstructionTypeCodeSystem
 Title: "Type of reconstruction surgery CodeSystem"
 Description: "Codes indicating the type of reconstruction surgery that is performed"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/ReconstructionTypeCodeSystem
+
 * insert CodeSystemRuleset
 
 * #direct-implant "Direct implant"
@@ -391,8 +347,6 @@ Id: ReconstructionTypeVS
 Title: "Type of reconstruction surgery ValueSet"
 Description: "Valueset of the type of reconstruction surgery that is performed"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ReconstructionTypeVS
-
 * include ReconstructionTypeCodeSystem#direct-implant "Direct implant"
 * include ReconstructionTypeCodeSystem#staged-implant "Staged implant"
 * include ReconstructionTypeCodeSystem#autologous "Autologous"
@@ -403,7 +357,7 @@ CodeSystem: ImplantLocationCodeSystem
 Id: ImplantLocationCodeSystem
 Title: "Location of the implant CodeSystem"
 Description: "Codes indicating the location of the implant that was placed during reconstruction surgery"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/ImplantLocationCodeSystem
+
 * insert CodeSystemRuleset
 
 * #pre-pectoral "Pre-pectoral"
@@ -414,11 +368,8 @@ Id: ImplantLocationVS
 Title: "Location of the implant ValueSet"
 Description: "Valueset of the location of the implant during reconstruction surgery"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ImplantLocationVS
-
 * include ImplantLocationCodeSystem#pre-pectoral "Pre-pectoral"
 * include ImplantLocationCodeSystem#sub-pectoral "Sub-pectoral"
-
 // Therapy intent
 ValueSet: TherapyIntentVS
 Id: TherapyIntentVS
@@ -426,8 +377,6 @@ Title: "Intent of therapy ValueSet"
 Description: "Valueset of intent of therapy"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TherapyIntentVS
-
 * SCT#373847000 "Neo-adjuvant - intent"
 * SCT#373846009 "Adjuvant - intent"
 * NullFlavor#UNK "unknown"
@@ -439,8 +388,6 @@ Title: "The location of radiotherapy ValueSet"
 Description: "Valueset of the location of radiotherapy"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/LocationRadiotherapyVS
-
 * SCT#76752008 "Breast structure"
 * SCT#78904004 "Chest wall structure"
 * SCT#68171009 "Axillary lymph node structure"
@@ -458,8 +405,6 @@ Title: "Type of chemotherapy ValueSet"
 Description: "Valueset of the types of chemotherapy"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ChemoTherapyTypeVS
-
 * SCT#108787006 "Medicinal product containing anthracycline and acting as antineoplastic agent"
 * SCT#418965003 "Taxane derivative"
 * SCT#768621002 "Product containing platinum and platinum compound"
@@ -474,8 +419,6 @@ Title: "Type of hormonal therapy ValueSet"
 Description: "Valueset of the types of hormonal therapy"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/HormonalTherapyTypeVS
-
 * SCT#413575009 "Substance with aromatase inhibitor mechanism of action"
 * SCT#373336003 "Substance with estrogen receptor antagonist mechanism of action"
 * SCT#83152002 "Oophorectomy"
@@ -490,8 +433,6 @@ Title: "Type of targeted therapy ValueSet"
 Description: "Valueset of the types of targeted therapy"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TargetedTherapyVS
-
 * SCT#784176007 "HER2 (Human epidermal growth factor receptor 2) inhibitor"
 * SCT#426265004 "Substance with protein kinase inhibitor mechanism of action"
 * SCT#432253008 "Substance with nicotinamide adenine dinucleotide adenosine diphosphate ribosyltransferase inhibitor mechanism of action"
@@ -503,7 +444,7 @@ CodeSystem: TreatmentPlanFollowedCodeSystem
 Id: TreatmentPlanFollowedCodeSystem
 Title: "Real Treatment Plan Followed CodeSystem"
 Description: "Codes covering if the patient followed the multidisciplinary recommended treatment plan"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/TreatmentPlanFollowedCodeSystem
+
 * insert CodeSystemRuleset
 
 * #no "No, not followed"
@@ -515,8 +456,6 @@ Id: TreatmentPlanFollowedVS
 Title: "Real Treatment Plan Followed ValueSet"
 Description: "Valueset of if the patient followed the multidisciplinary recommended treatment plan"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TreatmentPlanFollowedVS
-
 * TreatmentPlanFollowedCodeSystem#no "No, not followed"
 * TreatmentPlanFollowedCodeSystem#yes "Yes, fully followed"
 * TreatmentPlanFollowedCodeSystem#some "Some treatments followed"
@@ -525,7 +464,7 @@ CodeSystem: TreatmentPlanNotFollowedCodeSystem
 Id: TreatmentPlanNotFollowedCodeSystem
 Title: "Real Treatment Plan Not Followed CodeSystem"
 Description: "Codes covering if the patient has not followed the multidisciplinary recommended treatment plan"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/TreatmentPlanNotFollowedCodeSystem
+
 * insert CodeSystemRuleset
 
 * #patient-preference "Patient preference"
@@ -536,8 +475,6 @@ Id: TreatmentPlanNotFollowedVS
 Title: "Treatment Plan Not Followed ValueSet"
 Description: "Valueset of reason for the treatment plan not being followed"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TreatmentPlanNotFollowedVS
-
 * TreatmentPlanNotFollowedCodeSystem#patient-preference "Patient preference" // SCT#105480006 "Refusal of treatment by patient"
 * TreatmentPlanNotFollowedCodeSystem#clinical-reasons "Clinical reasons"
 * NullFlavor#UNK "unknown"
@@ -547,7 +484,7 @@ CodeSystem: PatientEducationCodeSystem
 Id: PatientEducationCodeSystem
 Title: "Patient Treatment Education Codesystem"
 Description: "Codes covering if the patient received sufficient information about the treatment options"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/PatientEducationCodeSystem
+
 * insert CodeSystemRuleset
 
 * #strongly-agree "Strongly agree"
@@ -561,8 +498,6 @@ Id: PatientEducationVS
 Title: "Patient Treatment Education ValueSet"
 Description: "Valueset covering if the patient received sufficient information about the treatment options"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/PatientEducationVS
-
 * PatientEducationCodeSystem#strongly-agree "Strongly agree"
 * PatientEducationCodeSystem#agree "Agree"
 * PatientEducationCodeSystem#somewhat-agree "Somewhat agree"
@@ -574,7 +509,7 @@ CodeSystem: PatientTreatPrefCodeSystem
 Id: PatientTreatPrefCodeSystem
 Title: "Patient treatment preference CodeSystem"
 Description: "Codes covering for why the treatment plan was not followed"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/PatientTreatPrefCodeSystem
+
 * insert CodeSystemRuleset
 
 * #personal-preference "Personal preference"
@@ -586,8 +521,6 @@ Title: "Patient treatment preference ValueSet"
 Description: "Valueset of reason for why the treatment plan was not followed"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/PatientTreatPrefVS
-
 * PatientTreatPrefCodeSystem#personal-preference "Personal preference" // SCT#105480006 "Refusal of treatment by patient"
 * SCT#309846006 "Treatment not available"
 * PatientTreatPrefCodeSystem#different-plan-recommended "Different plan recommended by clinical team"
@@ -597,7 +530,7 @@ CodeSystem: TreatmentPlanComplianceCodeSystem
 Id: TreatmentPlanComplianceCodeSystem
 Title: "Observation identifiers for treatment plan non-compliance reason CodeSystem"
 Description: "Codes covering observation identifiers for treatment plan non-compliance reaso"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/TreatmentPlanComplianceCodeSystem
+
 * insert CodeSystemRuleset
 
 * #reason-for-not-following "Reason for not following original treatment plan"
@@ -608,12 +541,8 @@ Id: TreatmentPlanComplianceVS
 Title: "Observation identifiers for treatment plan non-compliance reason ValueSet"
 Description: "Valueset of reason for why the treatment plan was not followed"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/TreatmentPlanComplianceVS
-
 * TreatmentPlanComplianceCodeSystem#reason-for-not-following "Reason for not following original treatment plan"
 * TreatmentPlanComplianceCodeSystem#patient-reason-for-not-following "Patient reported reason for not following recommened treatment"
-
-
 // DISUTILITY OF CARE
 // Reoperations
 ValueSet: ReoperationTypeVS
@@ -622,8 +551,6 @@ Title: "Type of re-operation"
 Description: "Valueset of the types of re-operation"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ReoperationTypeVS
-
 * SCT#33496007 "Reconstruction of breast"
 * SCT#69031006 "Excision of breast tissue"
 * SCT#234254000 "Excision of axillary lymph nodes group"
@@ -639,8 +566,6 @@ Title: "Re-operation due to involved margins ValueSet"
 Description: "Kind of re-operation due to involved margins"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/InvolvedMarginsReoperationTypeVS
-
 * SCT#373572006 "Clinical finding absent"
 * BreastSurgeryTypesCodeSystem#bcs "Breast conserving surgery (BCS)"
 * BreastSurgeryTypesCodeSystem#bcs-with-mammoplasty "BCS with mammoplasty"
@@ -654,8 +579,6 @@ Title: "Reasoncode of the re-operation"
 Description: "Valueset of the reasons of a re-operation"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ReoperationReasonVS
-
 * SCT#1156344002 "Presence of primary malignant neoplasm of breast at surgical margin in excised specimen of breast"
 * NullFlavor#OTH "other"
 
@@ -664,7 +587,7 @@ CodeSystem: ComplicationImpactCodeSystem
 Id: ComplicationImpactCodeSystem
 Title: "Impact of complication CodeSystem"
 Description: "Codes indicating the impact of a complication experienced by the breast cancer patient"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/ComplicationImpactCodeSystem
+
 * insert CodeSystemRuleset
 
 * #no-complication "No complication"
@@ -678,8 +601,6 @@ Title: "Impact of complication ValueSet"
 Description: "ValueSet of the impact of a complication experienced by the breast cancer patient"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ComplicationImpactVS
-
 * ComplicationImpactCodeSystem#no-complication "No complication"
 * SCT#240917005 "Interventional radiology"  
 * SCT#303577009 "Interventional debulking surgery" 
@@ -696,7 +617,7 @@ CodeSystem: ComplicationTypeCodeSystem
 Id: ComplicationTypeCodeSystem
 Title: "Type of complication CodeSystem"
 Description: "Codes indicating the type of a complication experienced by the breast cancer patient"
-* ^url =  http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/ComplicationTypeCodeSystem
+
 * insert CodeSystemRuleset
 
 * #partial-loss "Partial autologous graft loss"
@@ -710,8 +631,6 @@ Title: "Type of complication ValueSet"
 Description: "ValueSet of the type of complication experienced by the breast cancer patient"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/ComplicationTypeVS
-
 * SCT#76844004  "Local infection of wound"
 * SCT#715068009 "Seroma"
 * SCT#385494008 "Hematoma"
@@ -737,8 +656,6 @@ Title: "Yes, No and Unknown Valueset"
 Description: "Valueset with yes, no and unknown answers"
 * insert HL7CopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/NoYesUnknownVS
-
 * YesNoUnkCS#Y "Yes" 
 * YesNoUnkCS#N "No"
 * YesNoUnkCS#UNK "Unknown"
@@ -748,7 +665,7 @@ CodeSystem: RecurrenceCodeSystem
 Id: RecurrenceCodeSystem
 Title: "Recurrence of neoplasm CodeSystem"
 Description: "Additional code covering whether there is evidence of local, regional or distant recurrence of neoplasm"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/RecurrenceCodeSystem
+
 * insert CodeSystemRuleset
 
 * #local-recurrence "Yes, local recurrence"
@@ -760,8 +677,6 @@ Id: RecurrenceVS
 Title: "Recurrence of neoplasm ValueSet"
 Description: "Valueset about whether there is evidence of local, regional or distant recurrence of neoplasm"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/RecurrenceVS
-
 * YesNoUnkCS#N "No"
 * RecurrenceCodeSystem#local-recurrence "Yes, local recurrence"
 * RecurrenceCodeSystem#regional-recurrence "Yes, regional recurrence" 
@@ -772,7 +687,7 @@ CodeSystem: RecurrenceMethodCodeSystem
 Id: RecurrenceMethodCodeSystem
 Title: "Recurrence method CodeSystem"
 Description: "Additional code covering combination of radiological and histological diagnosis method"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/RecurrenceMethodCodeSystem
+
 * insert CodeSystemRuleset
 
 * #radiological-histological "Radiological and histological diagnosis"
@@ -783,14 +698,10 @@ Title: "Recurrence method ValueSet"
 Description: "Valueset of the methods used to confirm recurrence of breast cancer"
 * insert SNOMEDCopyrightForVS
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/RecurrenceMethodVS
-
 * SCT#394914008 "Radiology"
 * SCT#67151002 "Histologic"
 * RecurrenceMethodCodeSystem#radiological-histological "Radiological and histological diagnosis"
 * NullFlavor#UNK "unknown"
-
-
 //  DEGREE OF HEALTH 
 
 // EORTC-QLQ
@@ -798,7 +709,7 @@ CodeSystem: AgreementResponseCodeSystem
 Id: AgreementResponseCodeSystem
 Title: "Agreement response CodeSystem"
 Description: "Codes used in a Patient Reported Outcomes Instrument to express the degree of agreement"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/AgreementResponseCodeSystem
+
 * insert CodeSystemRuleset
 
 * #no "Not at all"
@@ -811,8 +722,6 @@ Id: AgreementResponseVS
 Title: "Agreement response ValueSet"
 Description: "Valueset used in a Patient Reported Outcomes Instrument to express the degree of agreement"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/AgreementResponseVS
-
 * AgreementResponseCodeSystem#no "Not at all"
 * AgreementResponseCodeSystem#little "A little"
 * AgreementResponseCodeSystem#quite "Quite a bit"
@@ -823,7 +732,7 @@ CodeSystem: SatisfactionResponseCodeSystem
 Id: SatisfactionResponseCodeSystem
 Title: "Satisfaction response CodeSystem"
 Description: "Codes used in a Patient Reported Outcomes Instrument to express the statisfation response"
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/CodeSystem/SatisfactionResponseCodeSystem
+
 * insert CodeSystemRuleset
 
 * #very-dissatisfied "Very dissatisfied"
@@ -836,8 +745,6 @@ Id: SatisfactionResponseVS
 Title: "Satisfaction response ValueSet"
 Description: "Valueset used in a Patient Reported Outcomes Instrument to express the statisfation response"
 * insert ValuesetRuleset
-* ^url = http://hl7.org/fhir/uv/ichom-breast-cancer/ValueSet/SatisfactionResponseVS
-
 * SatisfactionResponseCodeSystem#very-dissatisfied "Very dissatisfied"
 * SatisfactionResponseCodeSystem#somewhat-dissatisfied "Somewhat dissatisfied"
 * SatisfactionResponseCodeSystem#somewhat-satisfied "Somewhat satisfied"


### PR DESCRIPTION
Removed redundant URLs in terminology.fsh. These URLs caused an error using the latest version of SUSHI (3.0.0) but not in older versions (2.1.0). 